### PR TITLE
Make `realpath` canonicalize paths

### DIFF
--- a/win32/mingw.c
+++ b/win32/mingw.c
@@ -888,8 +888,11 @@ int link(const char *oldpath, const char *newpath)
 
 char *realpath(const char *path, char *resolved_path)
 {
-	/* FIXME: need normalization */
-	return strcpy(resolved_path, path);
+	if (_fullpath(resolved_path, path, PATH_MAX)) {
+		convert_slashes(resolved_path);
+		return resolved_path;
+	}
+	return NULL;
 }
 
 const char *get_busybox_exec_path(void)


### PR DESCRIPTION
I've had a need for `readlink` to fill out absolute paths from relative ones, so have modified the implementation of `realpath` in `mingw.c` to call the CRT function `_fullpath` , which canonicalizes relative paths on Windows.

I've built this on Ubuntu 16.04 running under WSL on Windows 10, with version 5.3.1 of the mingw32 cross-toolchain.